### PR TITLE
Fix integ tests with binary we build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,13 @@ compile-lambda-linux:
 tests:
 	go test ./...
 
-integ-tests-and-compile: compile-lambda-linux
+integ-tests-and-compile: tests compile-lambda-linux
 	python3 -m venv .venv
 	.venv/bin/pip install --upgrade pip
 	.venv/bin/pip install requests
 	.venv/bin/python3 test/integration/local_lambda/end-to-end-test.py
 
-integ-tests-with-docker: compile-with-docker
+integ-tests-with-docker: tests compile-with-docker
 	python3 -m venv .venv
 	.venv/bin/pip install --upgrade pip
 	.venv/bin/pip install requests

--- a/test/integration/local_lambda/end-to-end-test.py
+++ b/test/integration/local_lambda/end-to-end-test.py
@@ -33,7 +33,7 @@ class TestEndToEnd(TestCase):
 
 
     def test_env_var_with_eqaul_sign(self):
-        cmd = f"docker run --name envvarcheck -d -v {self.path_to_binary}:/local-lambda-runtime-server -p 9003:8080 --entrypoint /local-lambda-runtime-server/aws-lambda-local {self.image_name} /bootstrap-with-handler main.check_env_var_handler"
+        cmd = f"docker run --name envvarcheck -d -v {self.path_to_binary}:/local-lambda-runtime-server -p 9003:8080 --entrypoint /local-lambda-runtime-server/aws-lambda-rie {self.image_name} /bootstrap-with-handler main.check_env_var_handler"
 
         Popen(cmd.split(' ')).communicate()
 
@@ -44,7 +44,7 @@ class TestEndToEnd(TestCase):
         self.assertEqual(b'"4=4"', r.content)
 
     def test_two_invokes(self):
-        cmd = f"docker run --name testing -d -v {self.path_to_binary}:/local-lambda-runtime-server -p 9000:8080 --entrypoint /local-lambda-runtime-server/aws-lambda-local {self.image_name} /bootstrap-with-handler main.success_handler"
+        cmd = f"docker run --name testing -d -v {self.path_to_binary}:/local-lambda-runtime-server -p 9000:8080 --entrypoint /local-lambda-runtime-server/aws-lambda-rie {self.image_name} /bootstrap-with-handler main.success_handler"
 
         Popen(cmd.split(' ')).communicate()
 
@@ -60,7 +60,7 @@ class TestEndToEnd(TestCase):
 
 
     def test_timeout_invoke(self):
-        cmd = f"docker run --name timeout -d --env AWS_LAMBDA_FUNCTION_TIMEOUT=1 -v {self.path_to_binary}:/local-lambda-runtime-server -p 9001:8080 --entrypoint /local-lambda-runtime-server/aws-lambda-local {self.image_name} /bootstrap-with-handler main.sleep_handler"
+        cmd = f"docker run --name timeout -d --env AWS_LAMBDA_FUNCTION_TIMEOUT=1 -v {self.path_to_binary}:/local-lambda-runtime-server -p 9001:8080 --entrypoint /local-lambda-runtime-server/aws-lambda-rie {self.image_name} /bootstrap-with-handler main.sleep_handler"
 
         Popen(cmd.split(' ')).communicate()
 
@@ -71,7 +71,7 @@ class TestEndToEnd(TestCase):
         self.assertEqual(b"Task timed out after 1.00 seconds", r.content)
 
     def test_exception_returned(self):
-        cmd = f"docker run --name exception -d -v {self.path_to_binary}:/local-lambda-runtime-server -p 9002:8080 --entrypoint /local-lambda-runtime-server/aws-lambda-local {self.image_name} /bootstrap-with-handler main.exception_handler"
+        cmd = f"docker run --name exception -d -v {self.path_to_binary}:/local-lambda-runtime-server -p 9002:8080 --entrypoint /local-lambda-runtime-server/aws-lambda-rie {self.image_name} /bootstrap-with-handler main.exception_handler"
 
         Popen(cmd.split(' ')).communicate()
 
@@ -105,7 +105,7 @@ class TestPython36Runtime(TestCase):
         Popen(f"docker rmi {cls.image_name}".split(' ')).communicate()
 
     def test_invoke_with_pre_runtime_api_runtime(self):
-        cmd = f"docker run --name testing -d -v {self.path_to_binary}:/local-lambda-runtime-server -p 9000:8080 --entrypoint /local-lambda-runtime-server/aws-lambda-local {self.image_name} /bootstrap-with-handler main.success_handler"
+        cmd = f"docker run --name testing -d -v {self.path_to_binary}:/local-lambda-runtime-server -p 9000:8080 --entrypoint /local-lambda-runtime-server/aws-lambda-rie {self.image_name} /bootstrap-with-handler main.success_handler"
 
         Popen(cmd.split(' ')).communicate()
 
@@ -116,7 +116,7 @@ class TestPython36Runtime(TestCase):
         self.assertEqual(b'"My lambda ran succesfully"', r.content)
 
     def test_function_name_is_overriden(self):
-        cmd = f"docker run --name assert-overwritten -d --env AWS_LAMBDA_FUNCTION_NAME=MyCoolName -v {self.path_to_binary}:/local-lambda-runtime-server -p 9009:8080 --entrypoint /local-lambda-runtime-server/aws-lambda-local {self.image_name} /bootstrap-with-handler main.assert_env_var_is_overwritten"
+        cmd = f"docker run --name assert-overwritten -d --env AWS_LAMBDA_FUNCTION_NAME=MyCoolName -v {self.path_to_binary}:/local-lambda-runtime-server -p 9009:8080 --entrypoint /local-lambda-runtime-server/aws-lambda-rie {self.image_name} /bootstrap-with-handler main.assert_env_var_is_overwritten"
 
         Popen(cmd.split(' ')).communicate()
 


### PR DESCRIPTION
*Issue #, if available:*
Fix the binary name in the tests and always run unit tests before integ tests.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
