### PR TITLE
Use millisecond billing granularity

### DIFF
--- a/cmd/aws-lambda-rie/handlers.go
+++ b/cmd/aws-lambda-rie/handlers.go
@@ -54,7 +54,7 @@ func printEndReports(invokeId string, initDuration string, memorySize string, in
 			"Billed Duration: %.f ms\t"+
 			"Memory Size: %s MB\t"+
 			"Max Memory Used: %s MB\t\n",
-		invokeId, invokeDuration, math.Ceil(invokeDuration/100)*100, memorySize, memorySize)
+		invokeId, invokeDuration, math.Ceil(invokeDuration), memorySize, memorySize)
 }
 
 func InvokeHandler(w http.ResponseWriter, r *http.Request, sandbox Sandbox) {


### PR DESCRIPTION
Lambda now supports millisecond billing granularity (https://aws.amazon.com/blogs/aws/new-for-aws-lambda-1ms-billing-granularity-adds-cost-savings/), so this PR switches the `Billed duration` to millisecond granularity to match. ✨

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
