### PR TITLE
Fix mutex deadlock

### DIFF
--- a/lambda/rapidcore/server.go
+++ b/lambda/rapidcore/server.go
@@ -85,6 +85,7 @@ func (s *Server) GetInvokeTimeout() time.Duration {
 // Reserve allocates invoke context, returnes new invokeID
 func (s *Server) Reserve(id string) (string, *statejson.InternalStateDescription, error) {
 	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	if s.invokeCtx != nil {
 		return "", nil, ErrAlreadyReserved
@@ -99,8 +100,6 @@ func (s *Server) Reserve(id string) (string, *statejson.InternalStateDescription
 	}
 
 	s.reservationContext, s.reservationCancel = context.WithCancel(context.Background())
-
-	s.mutex.Unlock()
 
 	internalState, err := s.waitInit()
 	return invokeID, internalState, err


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
There was a chance of running into a deadlock if an invocation was already reserved. The change ensures the mutex is properly unlocked in all cases.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._