### PR TITLE
Fix name of memory env var in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ You can configure timeout by setting AWS_LAMBDA_FUNCTION_TIMEOUT to the number o
 
 The rest of these Environment Variables can be set to match AWS Lambda's environment but are not required.
 * `AWS_LAMBDA_FUNCTION_VERSION`
-* `AWS_LAMBDA_FUNCION_NAME`
-* `AWS_LAMBDA_MEMORY_SIZE`
+* `AWS_LAMBDA_FUNCTION_NAME`
+* `AWS_LAMBDA_FUNCTION_MEMORY_SIZE`
 
 ## Level of support
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

The key is `AWS_LAMBDA_FUNCTION_MEMORY_SIZE`, not
`AWS_LAMBDA_MEMORY_SIZE` (see its usage in the code [1])

[1] https://github.com/aws/aws-lambda-runtime-interface-emulator/blob/6a74e68cb79a256b771210e7c46a0ca2e1cea61b/lambda/rapidcore/env/constants.go#L26

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
