### PR TITLE
Fix integration tests

### DIFF
--- a/test/integration/local_lambda/end-to-end-test.py
+++ b/test/integration/local_lambda/end-to-end-test.py
@@ -27,7 +27,17 @@ class TestEndToEnd(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cmds_to_delete_images = ["docker rm -f envvarcheck", "docker rm -f testing", "docker rm -f timeout", "docker rm -f exception"]
+        cmds_to_delete_images = [
+            "docker rm -f envvarcheck",
+            "docker rm -f twoinvokes",
+            "docker rm -f customarn",
+            "docker rm -f arnexists",
+            "docker rm -f timeout",
+            "docker rm -f exception",
+            "docker rm -f remainingtimethree",
+            "docker rm -f remainingtimeten",
+            "docker rm -f remainingtimedefault",
+        ]
 
         for cmd in cmds_to_delete_images:
             Popen(cmd.split(' ')).communicate()
@@ -36,56 +46,18 @@ class TestEndToEnd(TestCase):
 
 
     def test_env_var_with_eqaul_sign(self):
-        cmd = f"docker run --name envvarcheck -d -v {self.path_to_binary}:/local-lambda-runtime-server -p 9003:8080 --entrypoint /local-lambda-runtime-server/aws-lambda-rie {self.image_name} {DEFAULT_1P_ENTRYPOINT} main.check_env_var_handler"
+        cmd = f"docker run --name envvarcheck -d -v {self.path_to_binary}:/local-lambda-runtime-server -p 9000:8080 --entrypoint /local-lambda-runtime-server/aws-lambda-rie {self.image_name} {DEFAULT_1P_ENTRYPOINT} main.check_env_var_handler"
 
         Popen(cmd.split(' ')).communicate()
 
         # sleep 1s to give enough time for the endpoint to be up to curl
         time.sleep(SLEEP_TIME)
 
-        r = requests.post("http://localhost:9003/2015-03-31/functions/function/invocations", json={})
+        r = requests.post("http://localhost:9000/2015-03-31/functions/function/invocations", json={})
         self.assertEqual(b'"4=4"', r.content)
 
     def test_two_invokes(self):
-        cmd = f"docker run --name testing -d -v {self.path_to_binary}:/local-lambda-runtime-server -p 9000:8080 --entrypoint /local-lambda-runtime-server/aws-lambda-rie {self.image_name} {DEFAULT_1P_ENTRYPOINT} main.success_handler"
-
-        Popen(cmd.split(' ')).communicate()
-
-        # sleep 1s to give enough time for the endpoint to be up to curl
-        time.sleep(SLEEP_TIME)
-
-        r = requests.post("http://localhost:9000/2015-03-31/functions/function/invocations", json={})
-        self.assertEqual(b'"My lambda ran succesfully"', r.content)
-
-        # Make sure we can invoke the function twice
-        r = requests.post("http://localhost:9000/2015-03-31/functions/function/invocations", json={})
-        self.assertEqual(b'"My lambda ran succesfully"', r.content) 
-
-    def test_lambda_function_arn_exists(self):
-        cmd = f"docker run --name testing -d -v {self.path_to_binary}:/local-lambda-runtime-server -p 9000:8080 --entrypoint /local-lambda-runtime-server/aws-lambda-rie {self.image_name} {DEFAULT_1P_ENTRYPOINT} main.assert_lambda_arn_in_context"
-
-        Popen(cmd.split(' ')).communicate()
-
-        # sleep 1s to give enough time for the endpoint to be up to curl
-        time.sleep(SLEEP_TIME)
-
-        r = requests.post("http://localhost:9000/2015-03-31/functions/function/invocations", json={})
-        self.assertEqual(b'"My lambda ran succesfully"', r.content)
-
-    def test_lambda_function_arn_exists_with_defining_custom_name(self):
-        cmd = f"docker run --name testing --env AWS_LAMBDA_FUNCTION_NAME=MyCoolName -d -v {self.path_to_binary}:/local-lambda-runtime-server -p 9000:8080 --entrypoint /local-lambda-runtime-server/aws-lambda-rie {self.image_name} {DEFAULT_1P_ENTRYPOINT} main.assert_lambda_arn_in_context"
-
-        Popen(cmd.split(' ')).communicate()
-
-        # sleep 1s to give enough time for the endpoint to be up to curl
-        time.sleep(SLEEP_TIME)
-
-        r = requests.post("http://localhost:9000/2015-03-31/functions/function/invocations", json={})
-        self.assertEqual(b'"My lambda ran succesfully"', r.content)
-
-
-    def test_timeout_invoke(self):
-        cmd = f"docker run --name timeout -d --env AWS_LAMBDA_FUNCTION_TIMEOUT=1 -v {self.path_to_binary}:/local-lambda-runtime-server -p 9001:8080 --entrypoint /local-lambda-runtime-server/aws-lambda-rie {self.image_name} {DEFAULT_1P_ENTRYPOINT} main.sleep_handler"
+        cmd = f"docker run --name twoinvokes -d -v {self.path_to_binary}:/local-lambda-runtime-server -p 9001:8080 --entrypoint /local-lambda-runtime-server/aws-lambda-rie {self.image_name} {DEFAULT_1P_ENTRYPOINT} main.success_handler"
 
         Popen(cmd.split(' ')).communicate()
 
@@ -93,10 +65,14 @@ class TestEndToEnd(TestCase):
         time.sleep(SLEEP_TIME)
 
         r = requests.post("http://localhost:9001/2015-03-31/functions/function/invocations", json={})
-        self.assertEqual(b"Task timed out after 1.00 seconds", r.content)
+        self.assertEqual(b'"My lambda ran succesfully"', r.content)
 
-    def test_exception_returned(self):
-        cmd = f"docker run --name exception -d -v {self.path_to_binary}:/local-lambda-runtime-server -p 9002:8080 --entrypoint /local-lambda-runtime-server/aws-lambda-rie {self.image_name} {DEFAULT_1P_ENTRYPOINT} main.exception_handler"
+        # Make sure we can invoke the function twice
+        r = requests.post("http://localhost:9001/2015-03-31/functions/function/invocations", json={})
+        self.assertEqual(b'"My lambda ran succesfully"', r.content)
+
+    def test_lambda_function_arn_exists(self):
+        cmd = f"docker run --name arnexists -d -v {self.path_to_binary}:/local-lambda-runtime-server -p 9002:8080 --entrypoint /local-lambda-runtime-server/aws-lambda-rie {self.image_name} {DEFAULT_1P_ENTRYPOINT} main.assert_lambda_arn_in_context"
 
         Popen(cmd.split(' ')).communicate()
 
@@ -104,45 +80,79 @@ class TestEndToEnd(TestCase):
         time.sleep(SLEEP_TIME)
 
         r = requests.post("http://localhost:9002/2015-03-31/functions/function/invocations", json={})
-        self.assertEqual(b'{"errorMessage": "Raising an exception", "errorType": "Exception", "stackTrace": ["  File \\"/var/task/main.py\\", line 13, in exception_handler\\n    raise Exception(\\"Raising an exception\\")\\n"]}', r.content)
+        self.assertEqual(b'"My lambda ran succesfully"', r.content)
 
-    def test_context_get_remaining_time_in_three_seconds(self):
-        cmd = f"docker run --name remainingtimethree -d --env AWS_LAMBDA_FUNCTION_TIMEOUT=3 -v {self.path_to_binary}:/local-lambda-runtime-server -p 9004:8080 --entrypoint /local-lambda-runtime-server/aws-lambda-rie {self.image_name} {DEFAULT_1P_ENTRYPOINT} main.check_remaining_time_handler"
+    def test_lambda_function_arn_exists_with_defining_custom_name(self):
+        cmd = f"docker run --name customarn --env AWS_LAMBDA_FUNCTION_NAME=MyCoolName -d -v {self.path_to_binary}:/local-lambda-runtime-server -p 9003:8080 --entrypoint /local-lambda-runtime-server/aws-lambda-rie {self.image_name} {DEFAULT_1P_ENTRYPOINT} main.assert_lambda_arn_in_context"
 
         Popen(cmd.split(' ')).communicate()
 
-        r = requests.post("http://localhost:9004/2015-03-31/functions/function/invocations", json={})
+        # sleep 1s to give enough time for the endpoint to be up to curl
+        time.sleep(SLEEP_TIME)
+
+        r = requests.post("http://localhost:9003/2015-03-31/functions/function/invocations", json={})
+        self.assertEqual(b'"My lambda ran succesfully"', r.content)
+
+
+    def test_timeout_invoke(self):
+        cmd = f"docker run --name timeout -d --env AWS_LAMBDA_FUNCTION_TIMEOUT=1 -v {self.path_to_binary}:/local-lambda-runtime-server -p 9004:8080 --entrypoint /local-lambda-runtime-server/aws-lambda-rie {self.image_name} {DEFAULT_1P_ENTRYPOINT} main.sleep_handler"
+
+        Popen(cmd.split(' ')).communicate()
 
         # sleep 1s to give enough time for the endpoint to be up to curl
         time.sleep(SLEEP_TIME)
+
+        r = requests.post("http://localhost:9004/2015-03-31/functions/function/invocations", json={})
+        self.assertEqual(b"Task timed out after 1.00 seconds", r.content)
+
+    def test_exception_returned(self):
+        cmd = f"docker run --name exception -d -v {self.path_to_binary}:/local-lambda-runtime-server -p 9005:8080 --entrypoint /local-lambda-runtime-server/aws-lambda-rie {self.image_name} {DEFAULT_1P_ENTRYPOINT} main.exception_handler"
+
+        Popen(cmd.split(' ')).communicate()
+
+        # sleep 1s to give enough time for the endpoint to be up to curl
+        time.sleep(SLEEP_TIME)
+
+        r = requests.post("http://localhost:9005/2015-03-31/functions/function/invocations", json={})
+        self.assertEqual(b'{"errorMessage": "Raising an exception", "errorType": "Exception", "stackTrace": ["  File \\"/var/task/main.py\\", line 13, in exception_handler\\n    raise Exception(\\"Raising an exception\\")\\n"]}', r.content)
+
+    def test_context_get_remaining_time_in_three_seconds(self):
+        cmd = f"docker run --name remainingtimethree -d --env AWS_LAMBDA_FUNCTION_TIMEOUT=3 -v {self.path_to_binary}:/local-lambda-runtime-server -p 9006:8080 --entrypoint /local-lambda-runtime-server/aws-lambda-rie {self.image_name} {DEFAULT_1P_ENTRYPOINT} main.check_remaining_time_handler"
+
+        Popen(cmd.split(' ')).communicate()
+
+        # sleep 1s to give enough time for the endpoint to be up to curl
+        time.sleep(SLEEP_TIME)
+
+        r = requests.post("http://localhost:9006/2015-03-31/functions/function/invocations", json={})
         # Executation time is not decided, 1.0s ~ 3.0s is a good estimation
         self.assertLess(int(r.content), 3000)
         self.assertGreater(int(r.content), 1000)
 
 
     def test_context_get_remaining_time_in_ten_seconds(self):
-        cmd = f"docker run --name remainingtimeten -d --env AWS_LAMBDA_FUNCTION_TIMEOUT=10 -v {self.path_to_binary}:/local-lambda-runtime-server -p 9005:8080 --entrypoint /local-lambda-runtime-server/aws-lambda-rie {self.image_name} {DEFAULT_1P_ENTRYPOINT} main.check_remaining_time_handler"
+        cmd = f"docker run --name remainingtimeten -d --env AWS_LAMBDA_FUNCTION_TIMEOUT=10 -v {self.path_to_binary}:/local-lambda-runtime-server -p 9007:8080 --entrypoint /local-lambda-runtime-server/aws-lambda-rie {self.image_name} {DEFAULT_1P_ENTRYPOINT} main.check_remaining_time_handler"
 
         Popen(cmd.split(' ')).communicate()
 
-        r = requests.post("http://localhost:9005/2015-03-31/functions/function/invocations", json={})
-
         # sleep 1s to give enough time for the endpoint to be up to curl
         time.sleep(SLEEP_TIME)
+
+        r = requests.post("http://localhost:9007/2015-03-31/functions/function/invocations", json={})
         # Executation time is not decided, 8.0s ~ 10.0s is a good estimation
         self.assertLess(int(r.content), 10000)
         self.assertGreater(int(r.content), 8000)
 
 
     def test_context_get_remaining_time_in_default_deadline(self):
-        cmd = f"docker run --name remainingtimedefault -d -v {self.path_to_binary}:/local-lambda-runtime-server -p 9006:8080 --entrypoint /local-lambda-runtime-server/aws-lambda-rie {self.image_name} {DEFAULT_1P_ENTRYPOINT} main.check_remaining_time_handler"
+        cmd = f"docker run --name remainingtimedefault -d -v {self.path_to_binary}:/local-lambda-runtime-server -p 9008:8080 --entrypoint /local-lambda-runtime-server/aws-lambda-rie {self.image_name} {DEFAULT_1P_ENTRYPOINT} main.check_remaining_time_handler"
 
         Popen(cmd.split(' ')).communicate()
 
-        r = requests.post("http://localhost:9006/2015-03-31/functions/function/invocations", json={})
-
         # sleep 1s to give enough time for the endpoint to be up to curl
         time.sleep(SLEEP_TIME)
+
+        r = requests.post("http://localhost:9008/2015-03-31/functions/function/invocations", json={})
         # Executation time is not decided, 298.0s ~ 300.0s is a good estimation
         self.assertLess(int(r.content), 300000)
         self.assertGreater(int(r.content), 298000)
@@ -164,7 +174,7 @@ class TestPython36Runtime(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cmds_to_delete_images = ["docker rm -f testing", "docker rm -f assert-overwritten"]
+        cmds_to_delete_images = ["docker rm -f api-runtime", "docker rm -f assert-overwritten"]
 
         for cmd in cmds_to_delete_images:
             Popen(cmd.split(' ')).communicate()
@@ -172,7 +182,7 @@ class TestPython36Runtime(TestCase):
         Popen(f"docker rmi {cls.image_name}".split(' ')).communicate()
 
     def test_invoke_with_pre_runtime_api_runtime(self):
-        cmd = f"docker run --name testing -d -v {self.path_to_binary}:/local-lambda-runtime-server -p 9000:8080 --entrypoint /local-lambda-runtime-server/aws-lambda-rie {self.image_name} {DEFAULT_1P_ENTRYPOINT} main.success_handler"
+        cmd = f"docker run --name api-runtime -d -v {self.path_to_binary}:/local-lambda-runtime-server -p 9000:8080 --entrypoint /local-lambda-runtime-server/aws-lambda-rie {self.image_name} {DEFAULT_1P_ENTRYPOINT} main.success_handler"
 
         Popen(cmd.split(' ')).communicate()
 
@@ -183,14 +193,14 @@ class TestPython36Runtime(TestCase):
         self.assertEqual(b'"My lambda ran succesfully"', r.content)
 
     def test_function_name_is_overriden(self):
-        cmd = f"docker run --name assert-overwritten -d --env AWS_LAMBDA_FUNCTION_NAME=MyCoolName -v {self.path_to_binary}:/local-lambda-runtime-server -p 9009:8080 --entrypoint /local-lambda-runtime-server/aws-lambda-rie {self.image_name} {DEFAULT_1P_ENTRYPOINT} main.assert_env_var_is_overwritten"
+        cmd = f"docker run --name assert-overwritten -d --env AWS_LAMBDA_FUNCTION_NAME=MyCoolName -v {self.path_to_binary}:/local-lambda-runtime-server -p 9001:8080 --entrypoint /local-lambda-runtime-server/aws-lambda-rie {self.image_name} {DEFAULT_1P_ENTRYPOINT} main.assert_env_var_is_overwritten"
 
         Popen(cmd.split(' ')).communicate()
 
         # sleep 1s to give enough time for the endpoint to be up to curl
         time.sleep(SLEEP_TIME)
 
-        r = requests.post("http://localhost:9009/2015-03-31/functions/function/invocations", json={})
+        r = requests.post("http://localhost:9001/2015-03-31/functions/function/invocations", json={})
         self.assertEqual(b'"My lambda ran succesfully"', r.content)
 
 


### PR DESCRIPTION
*Issue #, if available:*
* #47 

*Description of changes:*
The integration tests were failing due to multiple issues.

### Name conflicts

Multiple tests were using the same container name (`testing`),
which meant some of the tests weren't running. Now each container
has a unique name.

### Port conflicts

The same port (9000) was being used for multiple tests. This 
wasn't showing as an issue as these tests also used the same 
container name. The ports are now unique per test, with them 
being number sequentially to avoid any conflicts.

### Teardown properly

Only some of the running containers were terminated when the suite
finished executing. This caused many tests to not run properly on
subsequent invocation of the suite. Now all containers are
terminated when the tests complete.

### Wrong order of operations

The timeout tests weren't waiitng for the container be ready. This was
caused by the order of operations being wrong, with the sleep step
occurring after the request to the endpoint, not before.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
