### PR TITLE
Implement listen address argument and Rapid port argument

### DIFF
--- a/cmd/aws-lambda-rie/main.go
+++ b/cmd/aws-lambda-rie/main.go
@@ -24,6 +24,7 @@ type options struct {
 	LogLevel           string `long:"log-level" default:"info" description:"log level"`
 	InitCachingEnabled bool   `long:"enable-init-caching" description:"Enable support for Init Caching"`
 	ListenAddress      string `short:"l" long:"listen" default:"0.0.0.0:8080" description:"IP address and port to listen on."`
+	RapidPort          int    `long:"rapid-port" default:"9001" description:"Port for the Rapid backend server"`
 }
 
 func main() {
@@ -35,7 +36,7 @@ func main() {
 
 	bootstrap, handler := getBootstrap(args, opts)
 	sandbox := rapidcore.
-		NewSandboxBuilder(bootstrap).
+		NewSandboxBuilder(bootstrap, opts.RapidPort).
 		AddShutdownFunc(context.CancelFunc(func() { os.Exit(0) })).
 		SetExtensionsFlag(true).
 		SetInitCachingFlag(opts.InitCachingEnabled)

--- a/cmd/aws-lambda-rie/main.go
+++ b/cmd/aws-lambda-rie/main.go
@@ -23,7 +23,7 @@ const (
 type options struct {
 	LogLevel           string `long:"log-level" default:"info" description:"log level"`
 	InitCachingEnabled bool   `long:"enable-init-caching" description:"Enable support for Init Caching"`
-	ListenAddress      string `short:"l" long:"listen" description:"IP address and port to listen on. Defaults to '0.0.0.0:8080'"`
+	ListenAddress      string `short:"l" long:"listen" default:"0.0.0.0:8080" description:"IP address and port to listen on."`
 }
 
 func main() {
@@ -46,15 +46,7 @@ func main() {
 
 	go sandbox.Create()
 
-	var testAPIipport string
-
-	if opts.ListenAddress == "" {
-		testAPIipport = "0.0.0.0:8080"
-	} else {
-		testAPIipport = opts.ListenAddress
-	}
-
-	startHTTPServer(testAPIipport, sandbox)
+	startHTTPServer(opts.ListenAddress, sandbox)
 }
 
 func getCLIArgs() (options, []string) {

--- a/cmd/aws-lambda-rie/main.go
+++ b/cmd/aws-lambda-rie/main.go
@@ -23,6 +23,7 @@ const (
 type options struct {
 	LogLevel           string `long:"log-level" default:"info" description:"log level"`
 	InitCachingEnabled bool   `long:"enable-init-caching" description:"Enable support for Init Caching"`
+	ListenAddress      string `short:"l" long:"listen" description:"IP address and port to listen on. Defaults to '0.0.0.0:8080'"`
 }
 
 func main() {
@@ -45,7 +46,14 @@ func main() {
 
 	go sandbox.Create()
 
-	testAPIipport := "0.0.0.0:8080"
+	var testAPIipport string
+
+	if opts.ListenAddress == "" {
+		testAPIipport = "0.0.0.0:8080"
+	} else {
+		testAPIipport = opts.ListenAddress
+	}
+
 	startHTTPServer(testAPIipport, sandbox)
 }
 

--- a/lambda/rapid/sandbox.go
+++ b/lambda/rapid/sandbox.go
@@ -46,6 +46,7 @@ type Sandbox struct {
 	SignalCtx           context.Context
 	EventsAPI           telemetry.EventsAPI
 	InitCachingEnabled  bool
+	RapidPort           int
 }
 
 // Start is a public version of start() that exports only configurable parameters
@@ -60,7 +61,7 @@ func Start(s *Sandbox) {
 	if s.StandaloneMode {
 		s.InteropServer.SetInternalStateGetter(registrationService.GetInternalStateDescriptor(appCtx))
 	}
-	server := rapi.NewServer(RuntimeAPIHost, RuntimeAPIPort, appCtx, registrationService, renderingService, s.EnableTelemetryAPI, s.LogsSubscriptionAPI, s.InitCachingEnabled, credentialsService)
+	server := rapi.NewServer(RuntimeAPIHost, s.RapidPort, appCtx, registrationService, renderingService, s.EnableTelemetryAPI, s.LogsSubscriptionAPI, s.InitCachingEnabled, credentialsService)
 
 	postLoadTimeNs := metering.Monotime()
 

--- a/lambda/rapidcore/sandbox.go
+++ b/lambda/rapidcore/sandbox.go
@@ -64,7 +64,7 @@ const (
 	ExtensionLogSink
 )
 
-func NewSandboxBuilder(bootstrap *Bootstrap) *SandboxBuilder {
+func NewSandboxBuilder(bootstrap *Bootstrap, port int) *SandboxBuilder {
 	defaultInteropServer := NewServer(context.Background())
 	signalCtx, cancelSignalCtx := context.WithCancel(context.Background())
 	logsEgressAPI := &telemetry.NoOpLogsEgressAPI{}
@@ -84,6 +84,7 @@ func NewSandboxBuilder(bootstrap *Bootstrap) *SandboxBuilder {
 			SignalCtx:           signalCtx,
 			EventsAPI:           &telemetry.NoOpEventsAPI{},
 			InitCachingEnabled:  false,
+			RapidPort:           port,
 		},
 		defaultInteropServer: defaultInteropServer,
 		shutdownFuncs:        []context.CancelFunc{},


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*

Implements listen address argument (`-l|--listen <listen-address>`). If the argument is not supplied, it defaults to `0.0.0.0:8080` for backwards-compatibility.

Not sure whether to merge on `develop` or `main`, but develop is the default branch so I'm basing it on that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.