### PR TITLE
docs: adding Go version/release badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ## AWS Lambda Runtime Interface Emulator
+![GitHub release (latest by date)](https://img.shields.io/github/v/release/aws/aws-lambda-runtime-interface-emulator)
+![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/aws/aws-lambda-runtime-interface-emulator)
+![GitHub](https://img.shields.io/github/license/aws/aws-lambda-runtime-interface-emulator)
 
-![Apache-2.0](https://img.shields.io/npm/l/aws-sam-local.svg)
 
 The Lambda Runtime Interface Emulator is a proxy for Lambda’s Runtime and Extensions APIs, which allows customers to
 locally test their Lambda function packaged as a container image. It is a lightweight web-server that converts


### PR DESCRIPTION
Add Shield.io badges for Go version and GitHub release. Useful for displaying important information in a visually appealing and easily accessible way at a glance.

Updated the license badge to standard Shield.io format. As it appears it was incorrect pointing to the badge for 'aws-sam-local'.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
