### PR TITLE
docs: displaying environment variable as code snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ You can configure your credentials by setting:
 * `AWS_SESSION_TOKEN`
 * `AWS_REGION`
 
-You can configure timeout by setting AWS_LAMBDA_FUNCTION_TIMEOUT to the number of seconds you want your function to timeout in.
+You can configure timeout by setting `AWS_LAMBDA_FUNCTION_TIMEOUT` to the number of seconds you want your function to timeout in.
 
 The rest of these Environment Variables can be set to match AWS Lambda's environment but are not required.
 * `AWS_LAMBDA_FUNCTION_VERSION`


### PR DESCRIPTION
Added the markdown syntax to the singular environment variable in the README.md not displayed as a code snippet to be displayed as one, increasing readability.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
