### PR TITLE
CORS support. Allow OPTIONS request. Support requests from @aws-sdk/client-lambda

### DIFF
--- a/cmd/aws-lambda-rie/handlers.go
+++ b/cmd/aws-lambda-rie/handlers.go
@@ -65,7 +65,16 @@ func InvokeHandler(w http.ResponseWriter, r *http.Request, sandbox Sandbox) {
 		w.WriteHeader(500)
 		return
 	}
-
+	if origin := r.Header.Get("Origin"); origin != "" {
+		w.Header().Set("Access-Control-Allow-Origin", GetenvWithDefault("ACCESS_CONTROL_ALLOW_ORIGIN", origin))
+		w.Header().Set("Access-Control-Allow-Methods", GetenvWithDefault("ACCESS_CONTROL_ALLOW_METHODS", "POST, OPTIONS"))
+		w.Header().Set("Access-Control-Allow-Headers", GetenvWithDefault("ACCESS_CONTROL_ALLOW_HEADERS", "*"))
+		w.Header().Set("Access-Control-Allow-Credentials", GetenvWithDefault("ACCESS_CONTROL_ALLOW_CREDENTIALS", "true"))
+	}
+	if r.Method == "OPTIONS" {
+		w.WriteHeader(200)
+		return
+	}
 	initDuration := ""
 	inv := GetenvWithDefault("AWS_LAMBDA_FUNCTION_TIMEOUT", "300")
 	timeoutDuration, _ := time.ParseDuration(inv + "s")


### PR DESCRIPTION
Fixes https://github.com/aws/aws-lambda-runtime-interface-emulator/issues/16

Sets response headers allowing requests from browsers that send preflight OPTIONS requests. Previously using @aws-sdk/client-lambda returned CORS errors. Now requests and responses can be sent.

Test Plan: Build and run locally. Ensure curl -XPOST still works. Ensure requests from browsers now work and from @aws-sdk/client-lambda Test steps added to Contributing.md. Ensure `make integ-tests-and-compile` passes


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
