### PR TITLE
Allow for user-defined client context

### DIFF
--- a/test/integration/testdata/main.py
+++ b/test/integration/testdata/main.py
@@ -41,3 +41,7 @@ def check_remaining_time_handler(event, context):
     # Wait 1s to see if the remaining time changes
     time.sleep(1)
     return context.get_remaining_time_in_millis()
+
+
+def custom_client_context_handler(event, context):
+    return context.client_context.custom


### PR DESCRIPTION
*Issue #, if available:* 
Fixes #74 (and enables for https://github.com/aws/aws-sam-cli/issues/1177)


*Description of changes:*
As explained in the [Lambda Invoke documentation](https://docs.aws.amazon.com/lambda/latest/dg/API_Invoke.html), the client context is passed base64-encoded in the `X-Amz-Client-Context` header.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
