### PR TITLE
Refactored end-to-end tests

### DIFF
--- a/test/integration/local_lambda/test_end_to_end.py
+++ b/test/integration/local_lambda/test_end_to_end.py
@@ -100,7 +100,7 @@ class TestEndToEnd(TestCase):
         
         r = self.create_container_and_invoke_function(cmd, port)
         
-        self.assertEqual(b'"5=5"', r.content)
+        self.assertEqual(b'"4=4"', r.content)
 
     @parameterized.expand([("x86_64", "8001"), ("arm64", "9001"), ("", "9051")])
     def test_two_invokes(self, arch, port):

--- a/test/integration/local_lambda/test_end_to_end.py
+++ b/test/integration/local_lambda/test_end_to_end.py
@@ -100,7 +100,7 @@ class TestEndToEnd(TestCase):
         
         r = self.create_container_and_invoke_function(cmd, port)
         
-        self.assertEqual(b'"4=4"', r.content)
+        self.assertEqual(b'"5=5"', r.content)
 
     @parameterized.expand([("x86_64", "8001"), ("arm64", "9001"), ("", "9051")])
     def test_two_invokes(self, arch, port):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Refactored end-to-end tests to reduce duplicated code.

#### How to test:

Run the following commands
- docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
- sudo make integ-tests-with-docker

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
