### PR TITLE
Add automatic vulnerabilities check for released binaries

### DIFF
--- a/.github/workflows/check-binaries.yml
+++ b/.github/workflows/check-binaries.yml
@@ -1,0 +1,76 @@
+name: Check binaries
+
+on: 
+  workflow_dispatch:
+  schedule:
+   - cron: "0 16 * * 1-5"  # min h d Mo DoW / 9am PST M-F
+
+jobs:
+  check-for-vulnerabilities:
+    runs-on: ubuntu-latest
+    outputs:
+      report_contents: ${{ steps.save-output.outputs.report_contents }}
+    steps:
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+      - uses: robinraju/release-downloader@v1.10
+        with:
+          latest: true
+          fileName: 'aws-lambda-rie*'
+          out-file-path: "bin"
+      - name: Run check for vulnerabilities
+        id: check-binaries
+        run: |
+          make check-binaries
+      - if: always() && failure()   # Failure means there are vulnerabilities
+        id: save-output
+        name: Save output contents
+        run: |
+          report_csv="$(ls -tr output.cve-bin-*.csv 2>/dev/null | tail -n1)"   # last file generated
+          echo "Vulnerabilities stored in $report_csv"
+          final_report="${report_csv}.txt"
+          awk -F',' '{n=split($10, path, "/"); print $2,$3,$4,$5,path[n]}' "$report_csv" | column -t > "$final_report"   # make the CSV nicer
+          echo "report_contents<<EOF" >> "$GITHUB_OUTPUT"
+          cat "$final_report" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+      - if: always() && steps.check-binaries.outcome == 'failure'
+        name: Build new version and check
+        id: check-new-version
+        run: |
+          mkdir ./bin2
+          mv ./bin/* ./bin2
+          make compile-with-docker-all
+          latest_version=$(strings bin/aws-lambda-rie* | grep '^go1\.' | sort | uniq)
+          echo "latest_version=$latest_version" >> "$GITHUB_OUTPUT"
+          make check-binaries
+      - if: always() && steps.check-binaries.outcome == 'failure'
+        name: Save output for new version
+        id: save-new-version
+        run: |
+          exit_code=$?
+          if [ "${{ steps.check-new-version.outcome }}" == "failure" ]; then
+            fixed="No"
+          else
+            fixed="Yes"
+          fi
+          echo "fixed=$fixed" >> "$GITHUB_OUTPUT"
+      - if: always() && steps.check-binaries.outcome == 'failure'
+        name: Create Issue
+        id: create-issue
+        uses: dacbd/create-issue-action@main
+        with:
+          token: ${{ github.token }}
+          title: |
+            CVEs found in latest RIE release
+          body: |
+            ###  CVEs found in latest RIE release
+            ```
+            ${{ steps.save-output.outputs.report_contents }}
+            ```
+            
+            #### Are these resolved by building with the latest patch version of Go (${{ steps.check-new-version.outputs.latest_version }})?:
+            > **${{ steps.save-new-version.outputs.fixed }}**

--- a/.github/workflows/check-binaries.yml
+++ b/.github/workflows/check-binaries.yml
@@ -11,13 +11,16 @@ jobs:
     outputs:
       report_contents: ${{ steps.save-output.outputs.report_contents }}
     steps:
-      - uses: actions/setup-python@v5
+      - name: Setup python
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
         with:
           ref: main
-      - uses: robinraju/release-downloader@v1.10
+      - name: Download latest release
+        uses: robinraju/release-downloader@v1.10
         with:
           latest: true
           fileName: 'aws-lambda-rie*'
@@ -26,19 +29,19 @@ jobs:
         id: check-binaries
         run: |
           make check-binaries
-      - if: always() && failure()   # Failure means there are vulnerabilities
+      - if: always() && failure()   # `always()` to run even if the previous step failed. Failure means that there are vulnerabilities
+        name: Save content of the vulnerabilities report as GitHub output
         id: save-output
-        name: Save output contents
         run: |
           report_csv="$(ls -tr output.cve-bin-*.csv 2>/dev/null | tail -n1)"   # last file generated
           echo "Vulnerabilities stored in $report_csv"
           final_report="${report_csv}.txt"
           awk -F',' '{n=split($10, path, "/"); print $2,$3,$4,$5,path[n]}' "$report_csv" | column -t > "$final_report"   # make the CSV nicer
           echo "report_contents<<EOF" >> "$GITHUB_OUTPUT"
-          cat "$final_report" >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
+          cat "$final_report"         >> "$GITHUB_OUTPUT"
+          echo "EOF"                  >> "$GITHUB_OUTPUT"
       - if: always() && steps.check-binaries.outcome == 'failure'
-        name: Build new version and check
+        name: Build new binaries and check vulnerabilities again
         id: check-new-version
         run: |
           mkdir ./bin2
@@ -48,10 +51,9 @@ jobs:
           echo "latest_version=$latest_version" >> "$GITHUB_OUTPUT"
           make check-binaries
       - if: always() && steps.check-binaries.outcome == 'failure'
-        name: Save output for new version
+        name: Save outputs for the check with the latest build
         id: save-new-version
         run: |
-          exit_code=$?
           if [ "${{ steps.check-new-version.outcome }}" == "failure" ]; then
             fixed="No"
           else
@@ -59,7 +61,7 @@ jobs:
           fi
           echo "fixed=$fixed" >> "$GITHUB_OUTPUT"
       - if: always() && steps.check-binaries.outcome == 'failure'
-        name: Create Issue
+        name: Create GitHub Issue indicating vulnerabilities
         id: create-issue
         uses: dacbd/create-issue-action@main
         with:

--- a/Makefile
+++ b/Makefile
@@ -70,4 +70,7 @@ integ-tests-with-docker-old:
 	make ARCH=old compile-with-docker
 	make prep-python
 	make TEST_ARCH="" TEST_PORT=9052 exec-python-e2e-test
-	
+
+check-binaries: prep-python
+	.venv/bin/pip install cve-bin-tool
+	.venv/bin/python -m cve_bin_tool.cli bin/ -r go -d REDHAT,OSV,GAD,CURL --no-0-cve-report -f csv


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Run a vulnerability check over the released binaries. 
If there are vulnerabilities in the latest released binaries, then create an issue to call this out. Before creating the ticket, check if the vulnerabilities still exist when rebuilding the binaries with the same code, and include that info in the new issue. 

Example issue: https://github.com/valerena/aws-lambda-runtime-interface-emulator/issues/4

There's an improvement to be made to only create the issue if no issue has been created already. That's coming as a future improvement. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
