### PR TITLE
fix: correct typo in code comment

### DIFF
--- a/lambda/core/internalagent_states.go
+++ b/lambda/core/internalagent_states.go
@@ -55,7 +55,7 @@ func (s *InternalAgentRegisteredState) Ready() error {
 	return nil
 }
 
-// InitError - agent can transitions to InitErrorState if it failed to initialize
+// InitError - agent can transition to InitErrorState if it failed to initialize
 func (s *InternalAgentRegisteredState) InitError(errorType string) error {
 	s.agent.setStateUnsafe(s.agent.InitErrorState)
 	s.agent.errorType = errorType

--- a/lambda/interop/sandbox_model.go
+++ b/lambda/interop/sandbox_model.go
@@ -55,7 +55,7 @@ type InitSuccess struct {
 
 // InitFailure indicates that runtime/extensions initialization failed due to process exit or /error calls
 // In Rapid Shim, this translates to either a DONE or a DONEFAIL GirD message to Slicer (depending on extensions mode)
-// However, even on failure, the next invoke is expected to work with a suppressed init - i.e. we init again as aprt of the invoke
+// However, even on failure, the next invoke is expected to work with a suppressed init - i.e. we init again as part of the invoke
 type InitFailure struct {
 	ResetReceived       bool // indicates if failure happened due to a reset received
 	RequestReset        bool // Indicates whether reset should be requested on init failure


### PR DESCRIPTION
Minor typo fixes in comments.

Changed files:
- lambda/core/internalagent_states.go
- lambda/interop/sandbox_model.go


This change does not include functional changes.