### PR TITLE
chore(deps): Update to Go 1.24

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ DESTINATION_old:= bin/${BINARY_NAME}
 DESTINATION_x86_64 := bin/${BINARY_NAME}-x86_64
 DESTINATION_arm64 := bin/${BINARY_NAME}-arm64
 
-run_in_docker = docker run --env GOPROXY=direct -v $(shell pwd):/LambdaRuntimeLocal -w /LambdaRuntimeLocal golang:1.22 $(1)
+run_in_docker = docker run --env GOPROXY=direct -v $(shell pwd):/LambdaRuntimeLocal -w /LambdaRuntimeLocal golang:1.24 $(1)
 
 compile-with-docker-all:
 	$(call run_in_docker, make compile-lambda-linux-all)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.amzn.com
 
-go 1.22
+go 1.24
 
 require (
 	github.com/aws/aws-lambda-go v1.46.0

--- a/lambda/rapi/handler/agentnext.go
+++ b/lambda/rapi/handler/agentnext.go
@@ -35,14 +35,14 @@ func (h *agentNextHandler) ServeHTTP(writer http.ResponseWriter, request *http.R
 	if externalAgent, found := h.registrationService.FindExternalAgentByID(agentID); found {
 		if err := externalAgent.Ready(); err != nil {
 			log.Warnf("Ready() failed for %s: %s, state is %s", externalAgent.String(), err, externalAgent.GetState().Name())
-			rendering.RenderForbiddenWithTypeMsg(writer, request, errAgentInvalidState, "State transition from %s to %s failed for extension %s. Error: %s",
+			rendering.RenderForbiddenWithTypeMsg(writer, request, errAgentInvalidState, StateTransitionFailedForExtensionMessageFormat,
 				externalAgent.GetState().Name(), core.AgentReadyStateName, agentID.String(), err)
 			return
 		}
 	} else if internalAgent, found := h.registrationService.FindInternalAgentByID(agentID); found {
 		if err := internalAgent.Ready(); err != nil {
 			log.Warnf("Ready() failed for %s: %s, state is %s", internalAgent.String(), err, internalAgent.GetState().Name())
-			rendering.RenderForbiddenWithTypeMsg(writer, request, errAgentInvalidState, "State transition from %s to %s failed for extension %s. Error: %s",
+			rendering.RenderForbiddenWithTypeMsg(writer, request, errAgentInvalidState, StateTransitionFailedForExtensionMessageFormat,
 				internalAgent.GetState().Name(), core.AgentReadyStateName, agentID.String(), err)
 			return
 		}

--- a/lambda/rapi/handler/agentnext.go
+++ b/lambda/rapi/handler/agentnext.go
@@ -35,20 +35,20 @@ func (h *agentNextHandler) ServeHTTP(writer http.ResponseWriter, request *http.R
 	if externalAgent, found := h.registrationService.FindExternalAgentByID(agentID); found {
 		if err := externalAgent.Ready(); err != nil {
 			log.Warnf("Ready() failed for %s: %s, state is %s", externalAgent.String(), err, externalAgent.GetState().Name())
-			rendering.RenderForbiddenWithTypeMsg(writer, request, errAgentInvalidState, StateTransitionFailedForExtensionMessageFormat,
+			rendering.RenderForbiddenWithTypeMsg(writer, request, errAgentInvalidState, "State transition from %s to %s failed for extension %s. Error: %s",
 				externalAgent.GetState().Name(), core.AgentReadyStateName, agentID.String(), err)
 			return
 		}
 	} else if internalAgent, found := h.registrationService.FindInternalAgentByID(agentID); found {
 		if err := internalAgent.Ready(); err != nil {
 			log.Warnf("Ready() failed for %s: %s, state is %s", internalAgent.String(), err, internalAgent.GetState().Name())
-			rendering.RenderForbiddenWithTypeMsg(writer, request, errAgentInvalidState, StateTransitionFailedForExtensionMessageFormat,
+			rendering.RenderForbiddenWithTypeMsg(writer, request, errAgentInvalidState, "State transition from %s to %s failed for extension %s. Error: %s",
 				internalAgent.GetState().Name(), core.AgentReadyStateName, agentID.String(), err)
 			return
 		}
 	} else {
 		log.Warnf("Unknown agent %s tried to call /next", agentID.String())
-		rendering.RenderForbiddenWithTypeMsg(writer, request, errAgentIdentifierUnknown, "Unknown extension"+agentID.String())
+		rendering.RenderForbiddenWithTypeMsg(writer, request, errAgentIdentifierUnknown, "Unknown extension %s", agentID.String())
 		return
 	}
 

--- a/lambda/rapi/handler/agentregister.go
+++ b/lambda/rapi/handler/agentregister.go
@@ -77,7 +77,7 @@ func (h *agentRegisterHandler) ServeHTTP(writer http.ResponseWriter, request *ht
 
 	registerRequest, err := parseRegister(request)
 	if err != nil {
-		rendering.RenderForbiddenWithTypeMsg(writer, request, errInvalidRequestFormat, err.Error())
+		rendering.RenderForbiddenWithTypeMsg(writer, request, errInvalidRequestFormat, "%s", err.Error())
 		return
 	}
 
@@ -151,7 +151,7 @@ func (h *agentRegisterHandler) registerExternalAgent(
 
 	if err := agent.Register(registerRequest.Events); err != nil {
 		log.Warnf("Failed to register %s: %s", agent.String(), err)
-		rendering.RenderForbiddenWithTypeMsg(writer, request, errAgentInvalidState, StateTransitionFailedForExtensionMessageFormat,
+		rendering.RenderForbiddenWithTypeMsg(writer, request, errAgentInvalidState, "State transition from %s to %s failed for extension %s. Error: %s",
 			agent.GetState().Name(), core.AgentRegisteredStateName, agent.Name, err)
 		return
 	}
@@ -198,7 +198,7 @@ func (h *agentRegisterHandler) registerInternalAgent(
 
 	if err := agent.Register(registerRequest.Events); err != nil {
 		log.Warnf("Failed to register %s: %s", agent.String(), err)
-		rendering.RenderForbiddenWithTypeMsg(writer, request, errAgentInvalidState, StateTransitionFailedForExtensionMessageFormat,
+		rendering.RenderForbiddenWithTypeMsg(writer, request, errAgentInvalidState, "State transition from %s to %s failed for extension %s. Error: %s",
 			agent.GetState().Name(), core.AgentRegisteredStateName, agent.Name, err)
 		return
 	}

--- a/lambda/rapi/handler/agentregister.go
+++ b/lambda/rapi/handler/agentregister.go
@@ -151,7 +151,7 @@ func (h *agentRegisterHandler) registerExternalAgent(
 
 	if err := agent.Register(registerRequest.Events); err != nil {
 		log.Warnf("Failed to register %s: %s", agent.String(), err)
-		rendering.RenderForbiddenWithTypeMsg(writer, request, errAgentInvalidState, "State transition from %s to %s failed for extension %s. Error: %s",
+		rendering.RenderForbiddenWithTypeMsg(writer, request, errAgentInvalidState, StateTransitionFailedForExtensionMessageFormat,
 			agent.GetState().Name(), core.AgentRegisteredStateName, agent.Name, err)
 		return
 	}
@@ -198,7 +198,7 @@ func (h *agentRegisterHandler) registerInternalAgent(
 
 	if err := agent.Register(registerRequest.Events); err != nil {
 		log.Warnf("Failed to register %s: %s", agent.String(), err)
-		rendering.RenderForbiddenWithTypeMsg(writer, request, errAgentInvalidState, "State transition from %s to %s failed for extension %s. Error: %s",
+		rendering.RenderForbiddenWithTypeMsg(writer, request, errAgentInvalidState, StateTransitionFailedForExtensionMessageFormat,
 			agent.GetState().Name(), core.AgentRegisteredStateName, agent.Name, err)
 		return
 	}

--- a/lambda/rapi/handler/runtimelogs.go
+++ b/lambda/rapi/handler/runtimelogs.go
@@ -30,7 +30,7 @@ func (h *runtimeLogsHandler) ServeHTTP(writer http.ResponseWriter, request *http
 		log.Errorf("Agent Verification Error: %s", err)
 		switch err := err.(type) {
 		case *ErrAgentIdentifierUnknown:
-			rendering.RenderForbiddenWithTypeMsg(writer, request, errAgentIdentifierUnknown, "Unknown extension "+err.agentID.String())
+			rendering.RenderForbiddenWithTypeMsg(writer, request, errAgentIdentifierUnknown, "Unknown extension %s", err.agentID.String())
 			h.telemetrySubscription.RecordCounterMetric(telemetry.SubscribeClientErr, 1)
 		default:
 			rendering.RenderInternalServerError(writer, request)
@@ -55,7 +55,7 @@ func (h *runtimeLogsHandler) ServeHTTP(writer http.ResponseWriter, request *http
 		switch err {
 		case telemetry.ErrTelemetryServiceOff:
 			rendering.RenderForbiddenWithTypeMsg(writer, request,
-				h.telemetrySubscription.GetServiceClosedErrorType(), h.telemetrySubscription.GetServiceClosedErrorMessage())
+				h.telemetrySubscription.GetServiceClosedErrorType(), "%s", h.telemetrySubscription.GetServiceClosedErrorMessage())
 			h.telemetrySubscription.RecordCounterMetric(telemetry.SubscribeClientErr, 1)
 		default:
 			rendering.RenderInternalServerError(writer, request)

--- a/lambda/rapid/handlers.go
+++ b/lambda/rapid/handlers.go
@@ -233,18 +233,18 @@ func (c *rapidContext) watchEvents(events <-chan supvmodel.Event) {
 
 			// If event from the runtime.
 			if *termination.Name == runtimeProcessName {
-				if termination.Success() {
-					err = fmt.Errorf("Runtime exited without providing a reason")
-				} else {
-					err = fmt.Errorf("Runtime exited with error: %s", termination.String())
-				}
+			if termination.Success() {
+				err = fmt.Errorf("%s", "Runtime exited without providing a reason")
+			} else {
+				err = fmt.Errorf("%s: %s", "Runtime exited with error", termination.String())
+			}
 				appctx.StoreFirstFatalError(c.appCtx, fatalerror.RuntimeExit)
 			} else {
-				if termination.Success() {
-					err = fmt.Errorf("exit code 0")
-				} else {
-					err = fmt.Errorf(termination.String())
-				}
+			if termination.Success() {
+				err = fmt.Errorf("%s", "exit code 0")
+			} else {
+				err = fmt.Errorf("%s", termination.String())
+			}
 
 				appctx.StoreFirstFatalError(c.appCtx, fatalerror.AgentCrash)
 			}
@@ -851,7 +851,7 @@ func handleRestore(execCtx *rapidContext, restore *interop.Restore) (interop.Res
 	// check if there is any error stored in appctx to get the root cause error type
 	// Runtime.ExitError is an example to such a scenario
 	if fatalErrorFound {
-		err = fmt.Errorf(string(fatalErrorType))
+		err = fmt.Errorf("%s", string(fatalErrorType))
 	}
 
 	if err != nil {

--- a/lambda/rapid/handlers.go
+++ b/lambda/rapid/handlers.go
@@ -233,18 +233,18 @@ func (c *rapidContext) watchEvents(events <-chan supvmodel.Event) {
 
 			// If event from the runtime.
 			if *termination.Name == runtimeProcessName {
-			if termination.Success() {
-				err = fmt.Errorf("%s", "Runtime exited without providing a reason")
-			} else {
-				err = fmt.Errorf("%s: %s", "Runtime exited with error", termination.String())
-			}
+				if termination.Success() {
+					err = fmt.Errorf("Runtime exited without providing a reason")
+				} else {
+					err = fmt.Errorf("Runtime exited with error: %s", termination.String())
+				}
 				appctx.StoreFirstFatalError(c.appCtx, fatalerror.RuntimeExit)
 			} else {
-			if termination.Success() {
-				err = fmt.Errorf("%s", "exit code 0")
-			} else {
-				err = fmt.Errorf("%s", termination.String())
-			}
+				if termination.Success() {
+					err = fmt.Errorf("exit code 0")
+				} else {
+					err = fmt.Errorf("%s", termination.String())
+				}
 
 				appctx.StoreFirstFatalError(c.appCtx, fatalerror.AgentCrash)
 			}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
New format requirement in go 1.24:
lambda/rapid/handlers.go:246:23: non-constant format string in call to fmt.Errorf
Fix example: Instead of fmt.Printf(variableFormatString, value), use fmt.Printf("This is a %s: %d", "string", value)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
