### PR TITLE
feat: add environment variable support for runtime interface emulator address

### DIFF
--- a/cmd/aws-lambda-rie/main.go
+++ b/cmd/aws-lambda-rie/main.go
@@ -27,7 +27,7 @@ type options struct {
 	InitCachingEnabled bool   `long:"enable-init-caching" description:"Enable support for Init Caching"`
 	// Do not have a default value so we do not need to keep it in sync with the default value in lambda/rapidcore/sandbox_builder.go
 	RuntimeAPIAddress               string `long:"runtime-api-address" description:"The address of the AWS Lambda Runtime API to communicate with the Lambda execution environment."`
-	RuntimeInterfaceEmulatorAddress string `long:"runtime-interface-emulator-address" default:"0.0.0.0:8080" description:"The address for the AWS Lambda Runtime Interface Emulator to accept HTTP request upon."`
+	RuntimeInterfaceEmulatorAddress string `long:"runtime-interface-emulator-address" default:"0.0.0.0:8080" description:"The address for the AWS Lambda Runtime Interface Emulator to accept HTTP request upon. Can also be set by the environment variable 'RUNTIME_INTERFACE_EMULATOR_ADDRESS'."`
 }
 
 func main() {
@@ -48,6 +48,14 @@ func main() {
 	}
 
 	rapidcore.SetLogLevel(logLevel)
+
+	// Handle RuntimeInterfaceEmulatorAddress environment variable
+	// If CLI flag not provided, check environment variable
+	if opts.RuntimeInterfaceEmulatorAddress == "0.0.0.0:8080" {
+		if envAddress, envAddressSet := os.LookupEnv("RUNTIME_INTERFACE_EMULATOR_ADDRESS"); envAddressSet {
+			opts.RuntimeInterfaceEmulatorAddress = envAddress
+		}
+	}
 
 	if opts.RuntimeAPIAddress != "" {
 		_, _, err := net.SplitHostPort(opts.RuntimeAPIAddress)

--- a/test/integration/local_lambda/test_end_to_end.py
+++ b/test/integration/local_lambda/test_end_to_end.py
@@ -235,6 +235,30 @@ class TestEndToEnd(TestCase):
             self.assertEqual(b'"My lambda ran succesfully"', r.content)
 
 
+    def test_runtime_interface_emulator_address_env_var(self):
+        image, rie, image_name = self.tagged_name("rie_address_env_var")
+
+        # Use port 8081 inside the container and set via environment variable instead of CLI flag
+        params = f"--name {image} -d -v {self.path_to_binary}:/local-lambda-runtime-server -p {self.PORT}:8081 -e RUNTIME_INTERFACE_EMULATOR_ADDRESS=0.0.0.0:8081 --entrypoint /local-lambda-runtime-server/{rie} {image_name} {DEFAULT_1P_ENTRYPOINT} main.success_handler"
+
+        with self.create_container(params, image):
+            r = self.invoke_function()
+        
+            self.assertEqual(b'"My lambda ran succesfully"', r.content)
+
+
+    def test_runtime_interface_emulator_address_cli_precedence(self):
+        image, rie, image_name = self.tagged_name("rie_address_cli_precedence")
+
+        # Set environment variable but override with CLI flag - CLI should take precedence  
+        params = f"--name {image} -d -v {self.path_to_binary}:/local-lambda-runtime-server -p {self.PORT}:8082 -e RUNTIME_INTERFACE_EMULATOR_ADDRESS=0.0.0.0:8080 --entrypoint /local-lambda-runtime-server/{rie} {image_name} {DEFAULT_1P_ENTRYPOINT} main.success_handler --runtime-interface-emulator-address 0.0.0.0:8082"
+
+        with self.create_container(params, image):
+            r = self.invoke_function()
+        
+            self.assertEqual(b'"My lambda ran succesfully"', r.content)
+
+
     def test_custom_client_context(self):
         image, rie, image_name = self.tagged_name("custom_client_context")
 


### PR DESCRIPTION
## Summary
Add support for `RUNTIME_INTERFACE_EMULATOR_ADDRESS` environment variable to configure the emulator address without requiring CLI flags, addressing the need for easier configuration in containerized environments.

## Motivation
Currently, the runtime interface emulator address can only be configured via the `--runtime-interface-emulator-address` CLI flag. In containerized environments where the entrypoint script is hardcoded (like in AWS Lambda base images), users must patch the Docker image to customize this address, which is cumbersome.

This change enables configuration via environment variable while maintaining backward compatibility and following the established pattern used by `LOG_LEVEL`.

## Changes Made
- **Environment Variable Support**: Added `RUNTIME_INTERFACE_EMULATOR_ADDRESS` environment variable
- **AWS CLI Precedence Pattern**: CLI flag takes precedence over environment variable (consistent with AWS CLI behavior)
- **Documentation Update**: Updated help text to document the new environment variable
- **Comprehensive Testing**: Added integration tests for both environment variable usage and CLI precedence

## Implementation Details
- Follows the exact same pattern as existing `LOG_LEVEL` environment variable handling
- Uses `os.LookupEnv()` to check for environment variable when CLI flag is at default value
- Maintains all existing validation and error handling
- Zero breaking changes - fully backward compatible

## Usage Examples
```bash
# Set via environment variable
export RUNTIME_INTERFACE_EMULATOR_ADDRESS=127.0.0.1:9000
./aws-lambda-rie /lambda-entrypoint.sh handler

# CLI flag takes precedence (existing behavior)
./aws-lambda-rie --runtime-interface-emulator-address 127.0.0.1:9000 /lambda-entrypoint.sh handler

# Docker usage (addresses the original use case)
docker run -e RUNTIME_INTERFACE_EMULATOR_ADDRESS=0.0.0.0:8081 -p 8081:8081 my-lambda
```

## Test Coverage
- ✅ Environment variable usage test
- ✅ CLI flag precedence test  
- ✅ Backward compatibility (all existing tests pass)

Fixes #120

---
**Security Note**: This change only affects local development/testing environments where the Lambda Runtime Interface Emulator is used. No production Lambda runtime changes.