### PR TITLE
fix: replaces usage of deprecated io/ioutil

### DIFF
--- a/internal/lambda-managed-instances/testdata/env_setup_helpers.go
+++ b/internal/lambda-managed-instances/testdata/env_setup_helpers.go
@@ -6,7 +6,6 @@ package testdata
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -30,7 +29,7 @@ func CreateTestSocketPair(t *testing.T) (fd [2]int) {
 }
 
 func CreateTestLogFile(t *testing.T) *os.File {
-	file, err := ioutil.TempFile(os.TempDir(), "rapid-unit-tests")
+	file, err := os.CreateTemp(os.TempDir(), "rapid-unit-tests")
 	assert.NoError(t, err, "error opening tmp log file for test")
 	return file
 }

--- a/internal/lambda-managed-instances/testdata/flowtesting.go
+++ b/internal/lambda-managed-instances/testdata/flowtesting.go
@@ -6,7 +6,7 @@ package testdata
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 
 	"github.com/aws/aws-lambda-runtime-interface-emulator/internal/lambda-managed-instances/appctx"
 	"github.com/aws/aws-lambda-runtime-interface-emulator/internal/lambda-managed-instances/core"
@@ -29,7 +29,7 @@ type MockInteropServer struct {
 }
 
 func (i *MockInteropServer) SendResponse(invokeID string, resp *interop.StreamableInvokeResponse) (*interop.InvokeResponseMetrics, error) {
-	bytes, err := ioutil.ReadAll(resp.Payload)
+	bytes, err := io.ReadAll(resp.Payload)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/lambda/rie/handlers.go
+++ b/internal/lambda/rie/handlers.go
@@ -8,7 +8,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"net/http"
 	"os"
@@ -76,7 +76,7 @@ func printEndReports(invokeId string, initDuration string, memorySize string, in
 
 func InvokeHandler(w http.ResponseWriter, r *http.Request, sandbox Sandbox, bs interop.Bootstrap) {
 	log.Debugf("invoke: -> %s %s %v", r.Method, r.URL, r.Header)
-	bodyBytes, err := ioutil.ReadAll(r.Body)
+	bodyBytes, err := io.ReadAll(r.Body)
 	if err != nil {
 		log.Errorf("Failed to read invoke body: %s", err)
 		w.WriteHeader(500)

--- a/internal/lambda/testdata/flowtesting.go
+++ b/internal/lambda/testdata/flowtesting.go
@@ -6,7 +6,7 @@ package testdata
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"time"
 
 	"github.com/aws/aws-lambda-runtime-interface-emulator/internal/lambda/appctx"
@@ -32,7 +32,7 @@ type MockInteropServer struct {
 
 // SendResponse writes response to a shared memory.
 func (i *MockInteropServer) SendResponse(invokeID string, resp *interop.StreamableInvokeResponse) error {
-	bytes, err := ioutil.ReadAll(resp.Payload)
+	bytes, err := io.ReadAll(resp.Payload)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
*Description of changes:*
io/ioutil has been deprecated as of Go 1.16 ([source](https://pkg.go.dev/io/ioutil#pkg-overview))

This pull request replaces all `io/iotuil` usage with the `io` and `os` packages.

- `ioutil.TempFile` -> `os.CreateTemp` ([deprecation documentation](https://pkg.go.dev/io/ioutil#TempFile)
- `ioutil.ReadAll` -> `io.ReadAll` ([deprecation documentation](https://pkg.go.dev/io/ioutil#ReadAll))

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
