### PR TITLE
bump: go version to 1.25.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/aws-lambda-runtime-interface-emulator
 
-go 1.25.7
+go 1.25.8
 
 require (
 	github.com/aws/aws-lambda-go v1.46.0


### PR DESCRIPTION
Bumps Go from 1.25.7 to 1.25.8 to pick up security fixes to \`html/template\`, \`net/url\`, and \`os\` packages ([release notes](https://go.dev/doc/devel/release#go1.25.8)).